### PR TITLE
Remove FreeBSD specific compilation.

### DIFF
--- a/argon2.go
+++ b/argon2.go
@@ -5,8 +5,8 @@
 // (proof-of-work).
 package argon2
 
-// #cgo freebsd CFLAGS: -I/usr/local/include
-// #cgo freebsd LDFLAGS: -L/usr/local/lib -largon2
+// #cgo CFLAGS: -I/usr/local/include
+// #cgo LDFLAGS: -L/usr/local/lib -largon2
 // #include <stdlib.h>
 // #include <argon2.h>
 import "C"


### PR DESCRIPTION
Remove `freebsd` from `CFLAGS` and `LDFLAGS` passed to cgo so go-argon2 can be built on FreeBSD and OSX with go 1.6.
